### PR TITLE
Implement `--flowfacts-ignore-incomplete` for all otawa applications

### DIFF
--- a/include/otawa/app/Application.h
+++ b/include/otawa/app/Application.h
@@ -87,6 +87,7 @@ protected:
 	option::ListOption<string> sets;
 	option::ListOption<string> params;
 	option::ListOption<string> ff;
+	option::SwitchOption ff_ignore_incomplete;
 	option::Value<string> work_dir;
 	option::Value<string> dump_to;
 	option::SwitchOption record_stats;

--- a/include/otawa/flowfact/FlowFactLoader.h
+++ b/include/otawa/flowfact/FlowFactLoader.h
@@ -108,6 +108,7 @@ private:
 	Vector<xom::Element *> nodes;
 	Path current;
 	bool mandatory;
+	bool ignore_unknown;
 	bool lines_available;
 	dfa::State *state;
 	bool lib;

--- a/include/otawa/flowfact/features.h
+++ b/include/otawa/flowfact/features.h
@@ -35,6 +35,7 @@ namespace otawa {
 extern Identifier<Path> FLOW_FACTS_PATH;
 extern Identifier<xom::Element *> FLOW_FACTS_NODES;
 extern Identifier<bool> FLOW_FACTS_MANDATORY;
+extern Identifier<bool> FLOW_FACTS_IGNORE_UNKNOWN;
 
 // features
 extern p::feature FLOW_FACTS_FEATURE;

--- a/src/prog/app_Application.cpp
+++ b/src/prog/app_Application.cpp
@@ -293,6 +293,7 @@ Application::Application(const Make& make):
 	sets(option::ListOption<string>::Make(*this).cmd("--add-prop").description("set a configuration property").argDescription("ID=VALUE")),
 	params(option::ListOption<string>::Make(*this).cmd("--load-param").description("add a load parameter").argDescription("ID=VALUE")),
 	ff(option::ListOption<string>::Make(*this).cmd("--flowfacts").cmd("-f").description("select the flowfacts to load").argDescription("PATH")),
+	ff_ignore_incomplete(option::SwitchOption::Make(*this).cmd("--flowfacts-ignore-incomplete").description("ignore incomplete flowfacts (marked with '?')")),
 	work_dir(option::Value<string>::Make(*this).cmd("--work-dir").description("change the working directory").arg("PATH")),
 	dump_to(option::Value<string>::Make(*this).cmd("--dump-to").description("dump the results of analyzes to PATH").arg("PATH")),
 	record_stats(option::SwitchOption::Make(this).cmd("--stats").help("outputs available statistics in work directory")),
@@ -412,6 +413,8 @@ void Application::run() {
 		if(ff)
 			for(int i = 0; i < ff.count(); i++)
 				otawa::FLOW_FACTS_PATH(props).add(Path(ff[i]));
+		if(ff_ignore_incomplete)
+			otawa::FLOW_FACTS_IGNORE_UNKNOWN(props) = true;
 
 		// do the work
 		Monitor::configure(props);

--- a/src/prog/flowfact_FlowFactLoader.cpp
+++ b/src/prog/flowfact_FlowFactLoader.cpp
@@ -544,6 +544,8 @@ extern int fft_line;
  * 		by replacing extension or by appending ".ff" or ".ffx").
  * @li @ref otawa::FLOW_FACTS_MANDATORY -- if set to true, the processing fails if one loop bound is not available
  * 		(default to false).
+ * @li @ref otawa::FLOW_FACTS_IGNORE_UNKNOWN -- if set to true, the processing will not fails if one flow fact is unknown type
+ * 		(default to false).
  *
  * @see
  * 		@ref f4 for more details on the flow facts files.
@@ -568,6 +570,7 @@ FlowFactLoader::FlowFactLoader(p::declare& r):
 	
 	
 	mandatory(false),
+	ignore_unknown(false),
 	lines_available(false),
 	state(0),
 	lib(false),
@@ -589,6 +592,7 @@ void FlowFactLoader::configure (const PropList &props) {
 		nodes.add(*node);
 
 	mandatory = FLOW_FACTS_MANDATORY(props);
+	ignore_unknown = FLOW_FACTS_IGNORE_UNKNOWN(props);
 }
 
 
@@ -1218,7 +1222,8 @@ void FlowFactLoader::onMultiCall(Address control, const Vector<Address>& targets
  * @param addr	Address of the loop entry.
  */
 void FlowFactLoader::onUnknownLoop(Address addr) {
-	onError(_ << "no bound for loop at " << addr);
+	if(!ignore_unknown)
+		onError(_ << "no bound for loop at " << addr);
 }
 
 
@@ -1228,7 +1233,8 @@ void FlowFactLoader::onUnknownLoop(Address addr) {
  * @param control	Address of the control instruction.
  */
 void FlowFactLoader::onUnknownMultiBranch(Address control) {
-	onError(_ << "undefined targets for multi-branch at " << control);
+	if(!ignore_unknown)
+		onError(_ << "undefined targets for multi-branch at " << control);
 }
 
 
@@ -1238,7 +1244,8 @@ void FlowFactLoader::onUnknownMultiBranch(Address control) {
  * @param control	Address of the control instruction.
  */
 void FlowFactLoader::onUnknownMultiCall(Address control) {
-	onError(_ << "undefined targets for multi-call at " << control);
+	if(!ignore_unknown)
+		onError(_ << "undefined targets for multi-call at " << control);
 }
 
 /** 
@@ -2411,6 +2418,12 @@ Identifier<bool> EXIST_PROVIDED_STATE("otawa::EXISTPROVIDED_STATE", false);
  * @ingroup ff
  */
 Identifier<bool> FLOW_FACTS_MANDATORY("otawa::FLOW_FACTS_MANDATORY", false);
+
+/**
+ * In configuration of the FlowFactLoader, makes it ignore unknown flow facts
+ * @ingroup ff
+ */
+Identifier<bool> FLOW_FACTS_IGNORE_UNKNOWN("otawa::FLOW_FACTS_IGNORE_UNKNOWN", false);
 
 
 /**


### PR DESCRIPTION
All of OTAWA may now be used with incomplete flowfacts, whether they are structural (multibranch etc.) or for WCET computation (loop bounds). Of course, the WCET computation will still fail without loop bounds at the IPET stage, but that's unavoidable.

Demonstration:
```log
~/c/rocqstat-ng/b/bi/M7 static-cfg-pruning *20 !1 ?23 > ostat sieve_ram_thumb_ii_v7m.elf                            INT
ERROR: otawa::FlowFactLoader (1.4.0):sieve_ram_thumb_ii_v7m.elf.ff: 4: no bound for loop at 200007b8false
~/c/rocqstat-ng/b/bi/M7 static-cfg-pruning *20 !1 ?23 > ostat sieve_ram_thumb_ii_v7m.elf --flowfacts-ignore-incomplete
FUNCTION main
BB count = <not printable>
type = total count, average/bb, max/bb, ratio
instructions = 27, 3.85714, <not printable>, 100%
memory instructions = <not printable>, 1, <not printable>, 25.9259%
branch instructions = <not printable>, 0.857143, <not printable>, 22.2222%
```

Related: https://github.com/statinf-software/rocqstat-ng/issues/782