### PR TITLE
Implement `noblock` functionally directly through the AbstractCFGBuilder

### DIFF
--- a/src/prog/cfg_AbstractCFGBuilder.cpp
+++ b/src/prog/cfg_AbstractCFGBuilder.cpp
@@ -303,8 +303,17 @@ void AbstractCFGBuilder::buildEdges(CFGMaker& m) {
 				Inst *i = bb->control();
 
 				// conditional or call case -> sequential edge (not taken)
-				if(!i || (i->isConditional() && !IGNORE_SEQ(i)))
+				if(!i)
 					seq(m, bb, bb);
+				else if(i->isConditional() && !IGNORE_SEQ(i)) {
+					if(NO_BLOCK(i->nextInst())) {
+						// we also need to check the target of the seq branch is not NO_BLOCK
+						if(logFor(LOG_BB))
+							log << "\t\tskipping sequential edge " << i << " because " << i->nextInst()->address() << " is marked as NO_BLOCK\n";
+					}
+					else
+						seq(m, bb, bb);
+				}
 
 				// branch cases
 				if(i && !IGNORE_CONTROL(i)) {

--- a/src/prog/flowfact_FlowFactLoader.cpp
+++ b/src/prog/flowfact_FlowFactLoader.cpp
@@ -1391,7 +1391,6 @@ void FlowFactLoader::scanXBody(xom::Element *body, ContextualPath& cpath) {
 				else
 					onWarning(_ << "ignoring this because its address cannot be determined: " << xline(element));
 			}
-			}
 			else if(name == "noblock") {
 				Address addr = scanAddress(element, cpath).address();
 				if(!addr.isNull())


### PR DESCRIPTION
This implements `noblock` in `AbstractCFGBuilder`. It considers the case of sequential edges, and does leave a CFG with single-outgoing-taken-edge blocks, but this case is clearly foreseen in OTAWA because of the presence of the `noseq` flowfact item, that we emulate.