### PR TITLE
Ensure Safe Pointer Usage in `ProgItem` class

### DIFF
--- a/src/prog/prog_ProgItem.cpp
+++ b/src/prog/prog_ProgItem.cpp
@@ -43,7 +43,7 @@ ProgItem::~ProgItem(void) {
  */
 ProgItem *ProgItem::next(void) const {
 	ProgItem *result = (ProgItem *)inhstruct::DLNode::next(); 
-	if(result && result->atEnd())
+	if(!result || (result && result->atEnd()))
 		return 0;
 	else
 		return result;
@@ -56,7 +56,7 @@ ProgItem *ProgItem::next(void) const {
  */
 ProgItem *ProgItem::previous(void) const {
 	ProgItem *result = (ProgItem *)inhstruct::DLNode::previous(); 
-	if(result && result->atBegin())
+	if(!result || (result && result->atBegin()))
 		return 0;
 	else
 		return result;

--- a/src/prog/prog_ProgItem.cpp
+++ b/src/prog/prog_ProgItem.cpp
@@ -43,7 +43,7 @@ ProgItem::~ProgItem(void) {
  */
 ProgItem *ProgItem::next(void) const {
 	ProgItem *result = (ProgItem *)inhstruct::DLNode::next(); 
-	if(!result || result->atEnd())
+	if(result && result->atEnd())
 		return 0;
 	else
 		return result;
@@ -56,7 +56,7 @@ ProgItem *ProgItem::next(void) const {
  */
 ProgItem *ProgItem::previous(void) const {
 	ProgItem *result = (ProgItem *)inhstruct::DLNode::previous(); 
-	if(!result || result->atBegin())
+	if(result && result->atBegin())
 		return 0;
 	else
 		return result;


### PR DESCRIPTION
This PR completes https://github.com/statinf-otawa/elm/pull/1 with the goal of fixing memory leaks described in https://github.com/statinf-software/rocqstat-ng/issues/1354.